### PR TITLE
Add Cocoapods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 ###Integration
 TwitchKit enables you to embed a list of live channels, play live broadcasts and authenticate Twitch users in your iOS app with minimal effort.
 
-To add TwitchKit to your project, simply drop TwitchKit.framework and TwitchKit.bundle into the Frameworks section of your project in Xcode. Then, include the TwitchKit header file and invoke the presentStreamListForGameTitle:mode: with the name of your game:
+To add TwitchKit to your project, simply drop TwitchKit.framework and TwitchKit.bundle into the Frameworks section of your project in Xcode. 
+
+If you are using Cocoapods, simply add `pod 'TwitchKit'` to your Podfile.
+
+Then, include the TwitchKit header file and invoke the presentStreamListForGameTitle:mode: with the name of your game:
+
 
 `#import <TwitchKit/TwitchKit.h>`   
   
@@ -39,7 +44,7 @@ TwitchKit posts the following notifications to the default NSNotificationCenter:
 
 ###Requirements
 
-TwitchKit v2.0.1 should be deployed in applications that link against 7.0 and later versions of the iOS SDK. The Release and Debug binaries are compiled for armv7, armv7s and i386 architectures.
+TwitchKit v2.0.1 should be deployed in applications that link against 7.0 and later versions of the iOS SDK. The Release and Debug binaries are compiled for armv7, armv7s and i386 architectures. 
 
 You project should also link against the following standard libraries:
 * ImageIO.framework
@@ -48,6 +53,8 @@ You project should also link against the following standard libraries:
 * UIKit.framework
 * Foundation.framework
 * CoreGraphics.framework
+
+Note: If you are using Cocoapods to install TwitchKit, these requirements are added automatically.
 
 ###Changelog
 

--- a/TwitchKit.podspec
+++ b/TwitchKit.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |s|
+  s.name         = "TwitchKit"
+  s.version      = "2.0.1"
+  s.summary      = "A plug-in that enables browsing and playback of Twitch streams in iOS applications."
+
+  s.description  = <<-DESC
+                   TwitchKit enables you to embed a list of live channels, play live broadcasts and authenticate Twitch users in your iOS app with minimal effort.
+  DESC
+
+  s.homepage     = "twitch.tv"
+  s.license      = { :type => "EULA", :file => "LICENSE.md" }
+  s.author             = "twitch.tv"
+  s.platform     = :ios, "7.0"
+  s.source       = { :git => "https://github.com/twitchtv/twitch-ios-plugin-bin.git", :tag => s.version.to_s}
+  s.frameworks = "ImageIO", "CoreGraphics"
+  s.libraries = "c++", "z"
+
+  s.subspec "Debug" do |sub|
+    sub.vendored_frameworks = "Debug/TwitchKit.framework"
+    sub.public_header_files = "Debug/TwitchKit.framework/Versions/A/Headers/"
+    sub.resource_bundles = {
+      "TwitchKit" => ["Debug/TwitchKit.bundle/*"]
+    }
+  end
+
+  s.subspec "Release" do |sub|
+    sub.vendored_frameworks = "Release/TwitchKit.framework"
+    sub.public_header_files = "Release/TwitchKit.framework/Versions/A/Headers/"
+    sub.resource_bundles = {
+      "TwitchKit" => ["Release/TwitchKit.bundle/*"]
+    }
+  end
+
+  s.default_subspecs = "Release"
+end


### PR DESCRIPTION
Hello,

I've created a small patch to add a Cocoapods-podspec to your repository. Cocoapods allows for easier installation of frameworks like this one, and is de-facto standard in the iOS community. Adding the dependencies and the bundle contents is done automatically, for instance. 

Please consider accepting this pull request, as well as publishing the podspec file to the official Cocoapods repo, which would make the lives of this library's users much easier. 

You can find information on how to publish a podspec in the [official guide here](http://guides.cocoapods.org/making/getting-setup-with-trunk).